### PR TITLE
Add print_function future import

### DIFF
--- a/feature_extractor/rule_based_factuality.py
+++ b/feature_extractor/rule_based_factuality.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 import time


### PR DESCRIPTION
Probably related to https://github.com/cltl/multilingual_factuality/commit/d1cd4617445c04fc69541a3b08abd7aa1862c974

`print(termSpan, file=sys.stderr)` requires print to be a function, which in python2 requires the `from __future__ import print_function`. This works fine in python3 as well, so it should be safe to merge. 
